### PR TITLE
Initial Event Pagination

### DIFF
--- a/app/assets/javascripts/collections/events.js.coffee
+++ b/app/assets/javascripts/collections/events.js.coffee
@@ -1,5 +1,19 @@
 class Qwikstubs.Collections.Events extends Backbone.Collection
-  url: '/api/events'
+  initialize: ->
+    @page = 1
+
+  url: '/api/events?page=1'
+
+  nextPage: ->
+    @page += 1
+    @url = "/api/events?page=#{@page}"
+    @fetch(reset: true)
+
+  previousPage: ->
+    # handle more pages and less pages
+    @page -= 1
+    @url = "/api/events?page=#{@page}"
+    @fetch(reset: true)
   #model: Qwikstubs.Models.Venue
   
   # fetching records GET /venues

--- a/app/assets/javascripts/collections/events.js.coffee
+++ b/app/assets/javascripts/collections/events.js.coffee
@@ -1,6 +1,8 @@
 class Qwikstubs.Collections.Events extends Backbone.Collection
   initialize: ->
     @page = 1
+    # call this function to load the previous button to "disabled"
+    @previousPage() 
 
   url: '/api/events?page=1'
 
@@ -11,9 +13,12 @@ class Qwikstubs.Collections.Events extends Backbone.Collection
 
   previousPage: ->
     # handle more pages and less pages
-    @page -= 1
-    @url = "/api/events?page=#{@page}"
-    @fetch(reset: true)
+    if @page isnt 1
+      @page -= 1
+      @url = "/api/events?page=#{@page}"
+      @fetch(reset: true)
+    else
+      $('#previous-page').addClass("disabled")
   #model: Qwikstubs.Models.Venue
   
   # fetching records GET /venues

--- a/app/assets/javascripts/qwikstubs.js.coffee
+++ b/app/assets/javascripts/qwikstubs.js.coffee
@@ -3,9 +3,10 @@ window.Qwikstubs =
   Collections: {}
   Views: {}
   Routers: {}
-  initialize: -> 
-    Venues = new Qwikstubs.Routers.Venues()
-    Events = new Qwikstubs.Routers.Events()
+  initialize: ->
+    @Venues = new Qwikstubs.Routers.Venues()
+    @Events = new Qwikstubs.Routers.Events()
     Backbone.history.start()
+
 $(document).ready ->
   Qwikstubs.initialize()

--- a/app/assets/javascripts/routers/events_router.js.coffee
+++ b/app/assets/javascripts/routers/events_router.js.coffee
@@ -2,16 +2,15 @@ class Qwikstubs.Routers.Events extends Backbone.Router
   routes:
     'events': 'index'
     'events/:id': 'show'
-
+  
   initialize: ->
     @collection = new Qwikstubs.Collections.Events()
     @collection.fetch()
+    @eventIndex = new Qwikstubs.Views.EventsIndex(collection: @collection)
+    #@listenTo(@eventIndex.collection, 'reset', @index)
 
   index: ->
-    @collection = new Qwikstubs.Collections.Events()
-    @collection.fetch()
-    view = new Qwikstubs.Views.EventsIndex(collection: @collection)
-    $('#container').html(view.render().el)
+    $('#container').html(@eventIndex.render().el)
 
   show: (name) ->
     @collection = new Qwikstubs.Collections.Events()

--- a/app/assets/javascripts/routers/events_router.js.coffee
+++ b/app/assets/javascripts/routers/events_router.js.coffee
@@ -10,6 +10,7 @@ class Qwikstubs.Routers.Events extends Backbone.Router
     #@listenTo(@eventIndex.collection, 'reset', @index)
 
   index: ->
+    @collection.fetch() # investigate in the future
     $('#container').html(@eventIndex.render().el)
 
   show: (name) ->

--- a/app/assets/javascripts/routers/events_router.js.coffee
+++ b/app/assets/javascripts/routers/events_router.js.coffee
@@ -11,6 +11,7 @@ class Qwikstubs.Routers.Events extends Backbone.Router
 
   index: ->
     @collection.fetch() # investigate in the future
+    @collection.previousPage()
     $('#container').html(@eventIndex.render().el)
 
   show: (name) ->

--- a/app/assets/javascripts/views/events/event.js.coffee
+++ b/app/assets/javascripts/views/events/event.js.coffee
@@ -1,6 +1,6 @@
 class Qwikstubs.Views.Event extends Backbone.View
-
   template: JST['events/event']
+
   tagName: 'tr'
 
   render: ->

--- a/app/assets/javascripts/views/events/events_index.js.coffee
+++ b/app/assets/javascripts/views/events/events_index.js.coffee
@@ -1,22 +1,33 @@
 class Qwikstubs.Views.EventsIndex extends Backbone.View
+  tagName: 'div'
 
   template: JST['events/index']
 
-  #events:
+  events:
+    'click #next-page': 'nextPage'
+    'click #previous-page': 'previousPage'
+
   	#'submit #new_event' : 'createEvent'
 
   initialize: ->
-  	@collection.on('reset' , @render, @ )
-  	@collection.on('add' , @appendEventToList, @ )
+    @collection.on('reset', @render, @ )
+    @collection.on('add', @appendEventToList, @ )
 
   render: ->
-  	$(@el).html(@template())
-  	@collection.each(@appendEventToList)
-  	@
+    $(@el).html(@template())
+    @collection.each(@appendEventToList)
+    @
 
   appendEventToList: (event) ->
   	view = new Qwikstubs.Views.Event(model: event)
   	$('#list_event').append(view.render().el)
+  
+  nextPage: ->
+    @collection.nextPage()
+  
+  previousPage: ->
+    @collection.previousPage()
+    
 
   #createEvent: (event) ->
   	#event.preventDefault()

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,6 +14,10 @@
 
 body {background-image:url("/assets/dark.png");}
 
+/*#main {
+  height: 500px;
+}*/
+
 .form-signin {
 	max-width: 300px;
 	padding: 19px 29px 29px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -69,3 +69,19 @@ form.login > .btn {
 .logout-form {
     margin: 0px;
 }
+
+#footer {
+  color: #aaa;
+  width: 100%;
+  height: 50px;
+  text-align: center;
+  padding: 30px 0;
+  margin-top: 70px;
+  border-top: 1px solid #343434;
+  background-color: #454545;
+}
+
+.page-header.invert-text {
+  padding-bottom: 0px;
+  border-bottom: none;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -53,7 +53,7 @@ form.login input {
 
 /* TODO: needs a size tweak */
 form.login > .btn {
-  margin-top: 0px;
+  margin-top: -9px;
 }
 
 #logout-btn {

--- a/app/assets/templates/events/index.jst.eco
+++ b/app/assets/templates/events/index.jst.eco
@@ -20,6 +20,8 @@
 			  <tbody id="list_event">
 			  </tbody>
 		  </table>
+      <div id="next-page" class="btn" style="float: right">Next</div>
+      <div id="previous-page" class="btn">Prev</div>
     </div>
   </div>
 </div>

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,16 +2,21 @@ class EventsController < ApplicationController
   respond_to :json
 
   def index
-    respond_with Event.all
-  end  
-  
-  def list
     if page = params[:page]
-      puts page
-      respond_with Event.all
+      page_size = params[:pagesize] || 20
+      results = Event.paginate({ 
+        :order => :created_at.asc, 
+        :per_page => page_size, 
+        :page => page
+      })
+      respond_with results
     else
       respond_with Event.all
     end
+  end  
+  
+  def list
+   respond_with Event.all 
   end
   
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,11 +1,17 @@
 class EventsController < ApplicationController
   respond_to :json
+
   def index
     respond_with Event.all
   end  
   
   def list
-    respond_with Event.all
+    if page = params[:page]
+      puts page
+      respond_with Event.all
+    else
+      respond_with Event.all
+    end
   end
   
   def show

--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -2,8 +2,18 @@ class VenuesController < ApplicationController
   respond_to :json
 
   def index
-    respond_with Venue.all
-  end  
+    if page = params[:page]
+      page_size = params[:pagesize] || 20
+      results = Venue.paginate({ 
+        :order => :created_at.asc, 
+        :per_page => page_size, 
+        :page => page
+      })
+      respond_with results
+    else
+      respond_with Venue.all
+    end
+  end
 
   def list
     respond_with Venue.all

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -82,20 +82,14 @@
     <div class="container">
       <%= bootstrap_flash %>
       <%= yield %>
-
-      <div class="row">
-        <div class = "span12">
-          <footer class="well">
-          <%= bootstrap_flash %>	
-          <p><center>&copy; QwikStubs 2013</center></p>
-          </footer>
-        </div>
-      </div>
-      <div class = "row">
+      <!-- <div class = "row">
         <div class = "span12">
           <%= debug(params) if Rails.env.development? %>
         </div>
-      </div>
+      </div> -->
+    </div>
+    <div id="footer">
+      Qwikstubs 2013
     </div>
     <!-- Javascripts
     ================================================== -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
             <span class="icon-bar"></span>
           </button>
           <div class="nav" style="padding:2px;"> 
-            <%= image_tag 'logo-tiny.png', :alt => 'logo', :id => 'logo' %>
+            <%= link_to(image_tag('logo-tiny.png', :alt => 'logo', :id => 'logo'), root_path) %>
           </div>
           <ul class="nav">
             <!-- <li><%= link_to "Login", login_path %></li> -->
@@ -79,7 +79,7 @@
         </div>
       </div>
     </div>
-    <div class="container">
+    <div id="main" class="container">
       <%= bootstrap_flash %>
       <%= yield %>
       <!-- <div class = "row">


### PR DESCRIPTION
Implements basic paging functionality in the Event listing. The modifications are two fold: 
- modifies the 'Events#index' action to return a page if '?page=number' is appended to the request
- modifies the Event Backbone code to keep track of pages in the Events collection.
